### PR TITLE
Windows Support Fix

### DIFF
--- a/packages/loader/src/shared/cli.ts
+++ b/packages/loader/src/shared/cli.ts
@@ -110,7 +110,7 @@ export async function tryInitializePlasmicDir(
     plasmicDir,
     "node_modules",
     ".bin",
-    "plasmic"
+    process.platform === "win32" ? "plasmic.cmd":"plasmic"
   );
   const configPath = path.join(plasmicDir, "plasmic.json");
 

--- a/packages/loader/src/shared/index.ts
+++ b/packages/loader/src/shared/index.ts
@@ -17,7 +17,7 @@ export async function watchForChanges(
   { plasmicDir, pageDir }: PlasmicOpts,
   onRegisterPages?: onRegisterPages
 ) {
-  const cliPath = path.join(plasmicDir, "node_modules", ".bin", "plasmic");
+  const cliPath = path.join(plasmicDir, "node_modules", ".bin", process.platform === "win32" ? "plasmic.cmd":"plasmic");
   let currentConfig = await cli.readConfig(plasmicDir);
   const watchCmd = cp.spawn(
     "node",
@@ -99,7 +99,7 @@ export async function initLoader(userOpts: PlasmicOpts) {
     plasmicDir,
     "node_modules",
     ".bin",
-    "plasmic"
+    process.platform === "win32" ? "plasmic.cmd":"plasmic"
   );
 
   await cli.tryInitializePlasmicDir(plasmicDir, initArgs);


### PR DESCRIPTION
Fixed the support of the Windows platform through the usage of the wrapped batch files for the `plasmic` executable.