### PR TITLE
Ignore sub-dependencies in findInstalledPackageJsonFile

### DIFF
--- a/packages/cli/src/utils/npm-utils.ts
+++ b/packages/cli/src/utils/npm-utils.ts
@@ -169,7 +169,9 @@ function findInstalledPackageJsonFile(context: PlasmicContext, pkg: string) {
   const rootDir = packageJsonPath
     ? path.dirname(packageJsonPath)
     : context.rootDir;
-  const files = glob.sync(`${rootDir}/**/node_modules/${pkg}/package.json`);
+  const files = glob.sync(`${rootDir}/**/node_modules/${pkg}/package.json`, {
+    ignore:`**/node_modules/**/node_modules/**`
+  });
   return files.length > 0 ? files[0] : undefined;
 }
 


### PR DESCRIPTION
Please check #47 for more details on the bug.

https://github.com/plasmicapp/plasmic/issues/47#issuecomment-1207393135 explains how this patch works.
My solution is just a quick one to work around the problem for myself, but I do recommend that some extra effort is put into finding a better solution overall.

https://github.com/sindresorhus/resolve-cwd or https://github.com/sindresorhus/resolve-from might be more suitable than running such unnecessary and expensive glob. (I haven't tried fixing this bug with these packages and not sure they will work, but it's just something I recommend trying)