### PR TITLE
Add canonical to PageMetadata type

### DIFF
--- a/packages/loader-fetcher/src/api.ts
+++ b/packages/loader-fetcher/src/api.ts
@@ -29,6 +29,7 @@ export interface PageMetadata {
   title?: string | null;
   description?: string | null;
   openGraphImageUrl?: string | null;
+  canonical?: string | null;
 }
 
 export interface GlobalGroupMeta {


### PR DESCRIPTION
Adds a missing type for `canonical` for the `PageMetadata` type.