### PR TITLE
Fix: cli package version checking for pnpm

### DIFF
--- a/packages/cli/src/utils/npm-utils.ts
+++ b/packages/cli/src/utils/npm-utils.ts
@@ -74,7 +74,8 @@ export function findInstalledVersion(
     } else if (pm === "pnpm") {
       const output = execSync(`pnpm list --json ${pkg}`).toString().trim();
       const info = JSON.parse(output);
-      return info?.dependencies?.[pkg]?.version;
+      return info?.dependencies?.[pkg]?.version ||
+        info?.[0]?.dependencies?.[pkg]?.version;
     } else {
       // Unknown package manager (e.g. pnpm).
       const output = execSync(`npm list --json ${pkg}`).toString().trim();


### PR DESCRIPTION
Currently experiencing bug where CLI sync is not able to detect versions of dependencies properly when used with pnpm. 

Bug description: CLI might not be able to detect the plasmic package version properly when used together with pnpm package manager. The expected format of `pnpm list` could return array instead of object and that breaks ability to detect versions correctly.

Before this commit: if `pnpm list` returns array format the CLI will fail to detect version dependencies and will prompt user to update packages, even if all packages are set to latest versions.

After this commit: CLI can parse array format from pnpm command and detect package version correctly. Also keeping the original way to pull up the package version to avoid unexpected regressions.

The current pnpm implementation of return format:
- https://github.com/pnpm/pnpm/blob/main/reviewing/list/src/renderJson.ts#L44
- https://github.com/pnpm/pnpm/blob/main/reviewing/list/test/index.ts#L290

This is different behavior compared to regular npm:

```
$ pnpm list --json @plasmicapp/react-web
[
  {
    "name": "project-plasmic",
    "version": "1.0.0",
    "path": "/Users/user/Work/project-plasmic",
    "private": false,
    "dependencies": {
      "@plasmicapp/react-web": {
        "from": "@plasmicapp/react-web",
        "version": "0.2.221",
        "resolved": "file..."
      }
    }
  }
]

$ npm list --json @plasmicapp/react-web
{
  "version": "1.0.0",
  "name": "project-plasmic",
  "dependencies": {
    "@plasmicapp/cli": {
      "version": "0.1.287",
      "resolved": "file...",
      "dependencies": {
        "@plasmicapp/react-web": {
          "version": "0.2.221"
        }
      }
    },
    "@plasmicapp/react-web": {
      "version": "0.2.221",
      "resolved": "file..."
    }
  }
}

```