### PR TITLE
[create-plasmic-app] next js security improvement 🔐

### DIFF
--- a/packages/create-plasmic-app/src/nextjs/nextjs.ts
+++ b/packages/create-plasmic-app/src/nextjs/nextjs.ts
@@ -11,6 +11,7 @@ import {
 import { ensure } from "../utils/lang-utils";
 import { installUpgrade } from "../utils/npm-utils";
 import { CPAStrategy, GenerateFilesArgs } from "../utils/strategy";
+import { makeDotEnv_app_loader } from "./templates/app-loader/dot-env";
 import { makeCatchallPage_app_loader } from "./templates/app-loader/catchall-page";
 import { makePlasmicHostPage_app_loader } from "./templates/app-loader/plasmic-host";
 import { makePlasmicInit_app_loader } from "./templates/app-loader/plasmic-init";
@@ -107,7 +108,7 @@ async function generateFilesAppDir(args: GenerateFilesArgs) {
   // ./plasmic-init.ts
   await fs.writeFile(
     path.join(projectPath, `plasmic-init.${jsOrTs}`),
-    makePlasmicInit_app_loader(projectId, ensure(projectApiToken))
+    makePlasmicInit_app_loader()
   );
 
   // ./plasmic-init-client.ts
@@ -128,6 +129,13 @@ async function generateFilesAppDir(args: GenerateFilesArgs) {
   await fs.writeFile(
     path.join(projectPath, "app", "[[...catchall]]", `page.${jsOrTs}x`),
     makeCatchallPage_app_loader(jsOrTs)
+  );
+  
+  // ./.env.local
+  await fs.mkdir(path.join(projectPath, ".env.local"));
+  await fs.writeFile(
+    path.join(projectPath, ".env.local"),
+    makeDotEnv_app_loader(projectId, ensure(projectApiToken))
   );
 }
 

--- a/packages/create-plasmic-app/src/nextjs/templates/app-loader/dot-env.ts
+++ b/packages/create-plasmic-app/src/nextjs/templates/app-loader/dot-env.ts
@@ -1,0 +1,7 @@
+export function makeDotEnv_app_loader(
+  projectId: string,
+  projectApiToken: string
+): string {
+  return `PLASMIC_PROJECT_ID=${projectId}
+  PLASMIC_API_TOKEN=${projectApiToken}`
+};

--- a/packages/create-plasmic-app/src/nextjs/templates/app-loader/plasmic-init.ts
+++ b/packages/create-plasmic-app/src/nextjs/templates/app-loader/plasmic-init.ts
@@ -1,14 +1,11 @@
-export function makePlasmicInit_app_loader(
-  projectId: string,
-  projectApiToken: string
-): string {
+export function makePlasmicInit_app_loader(): string {
   return `import { initPlasmicLoader } from "@plasmicapp/loader-nextjs/react-server-conditional";
 
 export const PLASMIC = initPlasmicLoader({
   projects: [
     {
-      id: "${projectId}",
-      token: "${projectApiToken}",
+      id: process.env.PLASMIC_PROJECT_ID,
+      token: process.env.PLASMIC_API_TOKEN,
     },
   ],
 


### PR DESCRIPTION
I was about to commit code from the auto generated changes in `create-plasmic-app` script and noticed the secrets about to go to repo, I'm not sure how that really impacts security but have a hunch this info shouldn't be there...

There's no easy way I found to revoke previous api token in studio as well, so I'm guessing safe than sorry?

Since [nextJS supports dotenv ](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#loading-environment-variables)files natively and `.env.local` is auto ignored in git tracking, thought of adding this, wdyt?