### PR TITLE
[fetcher] Provide extended error data

### DIFF
--- a/plasmicpkgs/plasmic-query/src/Fetcher.tsx
+++ b/plasmicpkgs/plasmic-query/src/Fetcher.tsx
@@ -12,11 +12,17 @@ export interface GenericFetcherProps {
   errorDisplay?: ReactNode;
   previewErrorDisplay?: boolean;
   dataName?: string;
+  errorName?: string;
   noLayout?: boolean;
   className?: string;
 }
 
 type PropMetas<P> = ComponentMeta<P>["props"];
+
+type CustomError = Error & {
+  info: Record<string, any>;
+  status: number;
+};
 
 export const genericFetcherPropsMeta: PropMetas<GenericFetcherProps> = {
   children: "slot",
@@ -24,9 +30,15 @@ export const genericFetcherPropsMeta: PropMetas<GenericFetcherProps> = {
   errorDisplay: { type: "slot", defaultValue: "Error fetching data" },
   dataName: {
     type: "string",
-    displayName: "Variable name",
+    displayName: "Data name",
     defaultValue: "fetchedData",
     description: "Variable name to store the fetched data in",
+  },
+  errorName: {
+    type: "string",
+    displayName: "Error name",
+    defaultValue: "fetchError",
+    description: "Variable name to store the fetch error in",
   },
   previewSpinner: {
     type: "boolean",
@@ -55,6 +67,7 @@ export function GenericFetcherShell<T>({
   errorDisplay,
   previewErrorDisplay,
   dataName,
+  errorName,
   noLayout,
   className,
 }: GenericFetcherProps & {
@@ -67,7 +80,11 @@ export function GenericFetcherShell<T>({
   ) {
     return <>{loadingDisplay ?? null}</>;
   } else if ((inEditor && previewErrorDisplay) || "error" in result) {
-    return <>{errorDisplay ?? null}</>;
+    return (
+      <DataProvider name={errorName} data={result.error}>
+        {errorDisplay ?? null}
+      </DataProvider>
+    );
   } else {
     const content = (
       <DataProvider name={dataName} data={result.data}>
@@ -102,15 +119,28 @@ async function performFetch({ url, method, body, headers }: FetchProps) {
         ? body
         : JSON.stringify(body),
   });
-  if (!response.ok) {
-    throw new Error(response.statusText);
-  }
+
   const text = await response.text();
+  let json: Record<string, any> = { text };
+
   try {
-    return JSON.parse(text);
+    json = JSON.parse(text);
   } catch (e) {
-    return { text };
+    json = { text };
   }
+
+  // @see https://swr.vercel.app/docs/error-handling
+  // If the status code is not in the range 200-299,
+  // we still try to parse and throw it.
+  if (!response.ok) {
+    const error = new Error(response.statusText) as CustomError;
+    // Attach extra info to the error object.
+    error.info = json;
+    error.status = response.status;
+    throw error;
+  }
+
+  return json;
 }
 
 export interface DataFetcherProps extends FetchProps, GenericFetcherProps {


### PR DESCRIPTION
Problem:

It is not currently possible to access error response in plasmic-query package and therefore properly handle errors.

Solution: 

- Extend default error exception with info response from the server and status code as described in https://swr.vercel.app/docs/error-handling
- Provide it to the errorDisplay in a separate configurable errorName variable

https://forum.plasmic.app/t/accessing-graphql-and-http-api-fetcher-error-responses/5647

