### PR TITLE
[Draft] [radix-ui]: implement bindings for <Accordion/>

### DIFF
--- a/plasmicpkgs/radix-ui/package.json
+++ b/plasmicpkgs/radix-ui/package.json
@@ -44,6 +44,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-context-menu": "^2.1.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.5",

--- a/plasmicpkgs/radix-ui/src/accordion.tsx
+++ b/plasmicpkgs/radix-ui/src/accordion.tsx
@@ -1,0 +1,330 @@
+import constate from "constate";
+import React, { ComponentRef, ReactNode, forwardRef, useState } from "react";
+
+import { styled } from "@linaria/react";
+import {
+  DataProvider,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/loader-nextjs";
+import {
+  Content as AccordionContent,
+  Header as AccordionHeader,
+  Item as AccordionItem,
+  Root as AccordionRoot,
+  AccordionSingleProps,
+  Trigger as AccordionTrigger,
+} from "@radix-ui/react-accordion";
+import { Registerable, registerComponentHelper } from "./reg-util";
+
+const IMPORT_PATH = "@radix-ui/react-accordion";
+
+const getPlasmicComponentName = (componentName: string) =>
+  `radix-ui-${componentName}`;
+
+const getDisplayComponentName = (componentName: string) =>
+  `Radix-UI ${componentName}`;
+
+const getComponentNameAndImportMeta = (
+  componentName: string,
+  parentComponentName?: string,
+  opts?: {
+    displayName?: string;
+    importPath?: string;
+  }
+) => ({
+  name: getPlasmicComponentName(componentName),
+  displayName: opts?.displayName ?? getDisplayComponentName(componentName),
+  importPath: opts?.importPath ?? IMPORT_PATH,
+  importName: componentName,
+  ...(parentComponentName
+    ? { parentComponentName: getPlasmicComponentName(parentComponentName) }
+    : {}),
+});
+
+function useAccordionData({
+  defaultValue,
+  previewValue,
+}: {
+  defaultValue?: string;
+  previewValue?: string;
+}) {
+  const [activeValue, setActiveValue] = useState<string | undefined>(
+    defaultValue
+  );
+
+  const inEditor = usePlasmicCanvasContext();
+
+  return {
+    activeValue: inEditor ? previewValue || activeValue : activeValue,
+    setActiveValue,
+  };
+}
+
+const [AccordionProvider, useAccordionContextUnsafe] =
+  constate(useAccordionData);
+
+function RootDataProvider({ children }: { children?: ReactNode }) {
+  const { activeValue } = useAccordionContextUnsafe();
+
+  return (
+    <DataProvider name="activeValue" data={activeValue}>
+      {children}
+    </DataProvider>
+  );
+}
+
+interface RootProps extends InternalRootProps {
+  defaultValue?: string;
+  previewValue?: string;
+}
+
+const Root = forwardRef<ComponentRef<typeof AccordionRoot>, RootProps>(
+  (props, ref) => {
+    const { previewValue, defaultValue, ...rest } = props;
+
+    return (
+      <AccordionProvider
+        defaultValue={defaultValue}
+        previewValue={previewValue}
+      >
+        <RootDataProvider>
+          <InternalRoot {...rest} ref={ref} />
+        </RootDataProvider>
+      </AccordionProvider>
+    );
+  }
+);
+
+type InternalRootProps = Omit<
+  AccordionSingleProps,
+  "type" | "value" | "onValueChange" | "defaultValue"
+>;
+
+const InternalRoot = forwardRef<
+  ComponentRef<typeof AccordionRoot>,
+  InternalRootProps
+>((props, ref) => {
+  const { activeValue, setActiveValue } = useAccordionContextUnsafe();
+
+  return (
+    <AccordionRoot
+      {...props}
+      type="single"
+      value={activeValue}
+      onValueChange={setActiveValue}
+      ref={ref}
+    />
+  );
+});
+
+const ItemDataProvider = ({
+  value,
+  children,
+}: {
+  value: string;
+  children: ReactNode;
+}) => {
+  const { activeValue } = useAccordionContextUnsafe();
+
+  return (
+    <DataProvider name="open" data={value === activeValue}>
+      <DataProvider name="tabValue" data={value}>
+        {children}
+      </DataProvider>
+    </DataProvider>
+  );
+};
+
+const Item: typeof AccordionItem = forwardRef((props, ref) => {
+  return (
+    <ItemDataProvider value={props.value}>
+      <AccordionItem {...props} ref={ref} />
+    </ItemDataProvider>
+  );
+});
+
+const Content = styled(AccordionContent)`
+  overflow: hidden;
+
+  &[data-state="open"] {
+    animation: slideDown 300ms cubic-bezier(0.87, 0, 0.13, 1);
+  }
+
+  &[data-state="closed"] {
+    animation: slideUp 300ms cubic-bezier(0.87, 0, 0.13, 1);
+  }
+
+  @keyframes slideDown {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-accordion-content-height);
+    }
+  }
+
+  @keyframes slideUp {
+    from {
+      height: var(--radix-accordion-content-height);
+    }
+    to {
+      height: 0;
+    }
+  }
+`;
+
+export function registerAccordion(loader?: Registerable) {
+  registerComponentHelper(loader, Root, {
+    ...getComponentNameAndImportMeta("Accordion"),
+
+    styleSections: true,
+
+    defaultStyles: {
+      layout: "vbox",
+    },
+
+    providesData: true,
+
+    props: {
+      defaultValue: {
+        type: "string",
+        defaultValue: "tab1",
+      },
+
+      previewValue: {
+        type: "string",
+        description: "Show this tab while editing in Plasmic Studio",
+        defaultValue: "tab1",
+      },
+
+      collapsible: {
+        type: "boolean",
+        defaultValue: true,
+      },
+
+      disabled: {
+        type: "boolean",
+        defaultValue: false,
+      },
+
+      children: {
+        type: "slot",
+
+        defaultValue: [
+          {
+            type: "component",
+            name: getPlasmicComponentName("AccordionItem"),
+
+            props: {
+              value: "tab1",
+            },
+          },
+
+          {
+            type: "component",
+            name: getPlasmicComponentName("AccordionItem"),
+
+            props: {
+              value: "tab2",
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  registerComponentHelper(loader, Item, {
+    ...getComponentNameAndImportMeta("AccordionItem"),
+
+    styleSections: true,
+
+    defaultStyles: {
+      layout: "vbox",
+    },
+
+    props: {
+      value: {
+        type: "string",
+        required: true,
+      },
+
+      children: {
+        type: "slot",
+
+        defaultValue: [
+          {
+            type: "component",
+            name: getPlasmicComponentName("AccordionHeader"),
+          },
+
+          {
+            type: "component",
+            name: getPlasmicComponentName("AccordionContent"),
+          },
+        ],
+      },
+    },
+  });
+
+  registerComponentHelper(loader, AccordionHeader, {
+    ...getComponentNameAndImportMeta("AccordionHeader"),
+
+    styleSections: true,
+
+    providesData: true,
+
+    props: {
+      children: {
+        type: "slot",
+
+        defaultValue: [
+          {
+            type: "component",
+            name: getPlasmicComponentName("AccordionTrigger"),
+          },
+        ],
+      },
+    },
+  });
+
+  registerComponentHelper(loader, AccordionTrigger, {
+    ...getComponentNameAndImportMeta("AccordionTrigger"),
+
+    styleSections: true,
+
+    defaultStyles: {
+      layout: "hbox",
+    },
+
+    props: {
+      children: {
+        type: "slot",
+
+        defaultValue: [
+          {
+            type: "text",
+            value: "Expand text",
+          },
+        ],
+      },
+    },
+  });
+
+  registerComponentHelper(loader, Content, {
+    ...getComponentNameAndImportMeta("AccordionContent"),
+
+    styleSections: true,
+
+    props: {
+      children: {
+        type: "slot",
+
+        defaultValue: {
+          type: "text",
+          value:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam fringilla porttitor risus in ullamcorper. In molestie enim sapien, non blandit libero scelerisque ut. Donec imperdiet iaculis urna sit amet accumsan. Nam neque nunc, tincidunt vitae fringilla id, hendrerit et ex.",
+        },
+      },
+    },
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6726,6 +6726,22 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-accordion@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-accordion/-/react-accordion-1.1.2.tgz#738441f7343e5142273cdef94d12054c3287966f"
+  integrity sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collapsible" "1.0.3"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
 "@radix-ui/react-arrow@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
@@ -6733,6 +6749,21 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-collapsible@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.0.3.tgz#df0e22e7a025439f13f62d4e4a9e92c4a0df5b81"
+  integrity sha512-UBmVDkmR6IvDsloHVN+3rtx4Mi5TFvylYXpluuv0f37dtaz3H99bp8No0LGXRigVpl3UAT4l9j6bIchh42S/Gg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
 
 "@radix-ui/react-collection@1.0.3":
   version "1.0.3"


### PR DESCRIPTION
I first implemented these bindings in my project and then i copy-pasted the code into the Plasmic's repo and i tried to port as much as i could to conform to how other radix components are implemented here,

but the code for animations here is kind of convoluted for me so i just left my (obviously not working in this repo) css-in-js class name. So i need help with porting that.

Also, should `getPlasmicComponentName` and `getDisplayComponentName` be changed to match how other components are notated?