### PR TITLE
[fetcher] useSWRMutation, add state, extended configuration in Studio

### DIFF
--- a/plasmicpkgs/plasmic-query/package.json
+++ b/plasmicpkgs/plasmic-query/package.json
@@ -42,5 +42,8 @@
     "@plasmicapp/query": ">=0.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
+  },
+  "dependencies": {
+    "swr": "2.2.4"
   }
 }

--- a/plasmicpkgs/plasmic-query/src/Fetcher.tsx
+++ b/plasmicpkgs/plasmic-query/src/Fetcher.tsx
@@ -12,11 +12,17 @@ export interface GenericFetcherProps {
   errorDisplay?: ReactNode;
   previewErrorDisplay?: boolean;
   dataName?: string;
+  errorName?: string;
   noLayout?: boolean;
   className?: string;
 }
 
 type PropMetas<P> = ComponentMeta<P>["props"];
+
+type CustomError = Error & {
+  info: Record<string, any>;
+  status: number;
+};
 
 export const genericFetcherPropsMeta: PropMetas<GenericFetcherProps> = {
   children: "slot",
@@ -24,9 +30,15 @@ export const genericFetcherPropsMeta: PropMetas<GenericFetcherProps> = {
   errorDisplay: { type: "slot", defaultValue: "Error fetching data" },
   dataName: {
     type: "string",
-    displayName: "Variable name",
+    displayName: "Data name",
     defaultValue: "fetchedData",
     description: "Variable name to store the fetched data in",
+  },
+  errorName: {
+    type: "string",
+    displayName: "Error name",
+    defaultValue: "fetchError",
+    description: "Variable name to store the fetch error in",
   },
   previewSpinner: {
     type: "boolean",
@@ -55,6 +67,7 @@ export function GenericFetcherShell<T>({
   errorDisplay,
   previewErrorDisplay,
   dataName,
+  errorName,
   noLayout,
   className,
 }: GenericFetcherProps & {
@@ -67,7 +80,11 @@ export function GenericFetcherShell<T>({
   ) {
     return <>{loadingDisplay ?? null}</>;
   } else if ((inEditor && previewErrorDisplay) || "error" in result) {
-    return <>{errorDisplay ?? null}</>;
+    return (
+      <DataProvider name={errorName} data={result.error}>
+        {errorDisplay ?? null}
+      </DataProvider>
+    );
   } else {
     const content = (
       <DataProvider name={dataName} data={result.data}>
@@ -102,15 +119,28 @@ async function performFetch({ url, method, body, headers }: FetchProps) {
         ? body
         : JSON.stringify(body),
   });
-  if (!response.ok) {
-    throw new Error(response.statusText);
-  }
+
   const text = await response.text();
+  let json: Record<string, any> = { text };
+
   try {
-    return JSON.parse(text);
+    json = JSON.parse(text);
   } catch (e) {
-    return { text };
+    json = { text };
   }
+
+  // @see https://swr.vercel.app/docs/error-handling
+  // If the status code is not in the range 200-299,
+  // we still try to parse and throw it.
+  if (!response.ok) {
+    const error = new Error(response.statusText) as CustomError;
+    // Attach extra info to the error object.
+    error.info = json;
+    error.status = response.status;
+    throw error;
+  }
+
+  return json;
 }
 
 export interface DataFetcherProps extends FetchProps, GenericFetcherProps {

--- a/plasmicpkgs/plasmic-query/src/Fetcher.tsx
+++ b/plasmicpkgs/plasmic-query/src/Fetcher.tsx
@@ -2,10 +2,16 @@ import { DataProvider, usePlasmicCanvasContext } from "@plasmicapp/host";
 import registerComponent, {
   ComponentMeta,
 } from "@plasmicapp/host/registerComponent";
-import { usePlasmicQueryData } from "@plasmicapp/query";
+import { SWRResponse, SWRConfiguration, useSWRConfig, Cache } from "swr";
+import useSWRMutation, {
+  SWRMutationResponse,
+  SWRMutationConfiguration,
+} from "swr/mutation";
 import React, { ReactNode } from "react";
+import { useMutablePlasmicQueryData, usePlasmicDataConfig } from "@plasmicapp/react-web/lib/query";
 
-export interface GenericFetcherProps {
+export interface GenericFetcherProps
+  extends Omit<FetcherOptions, "isVisible" | "isOnline"> {
   children?: ReactNode;
   loadingDisplay?: ReactNode;
   previewSpinner?: boolean;
@@ -15,6 +21,9 @@ export interface GenericFetcherProps {
   errorName?: string;
   noLayout?: boolean;
   className?: string;
+  onResultChange?: (result: FetcherResult) => void;
+  useMutation?: boolean;
+  disabled?: boolean;
 }
 
 type PropMetas<P> = ComponentMeta<P>["props"];
@@ -22,6 +31,16 @@ type PropMetas<P> = ComponentMeta<P>["props"];
 type CustomError = Error & {
   info: Record<string, any>;
   status: number;
+};
+
+type FetcherQueryResult = SWRResponse<any, CustomError>;
+
+type FetcherMutationResult = SWRMutationResponse<any, CustomError>
+
+type FetcherResult = FetcherQueryResult & FetcherMutationResult;
+
+type FetcherOptions = SWRConfiguration<any, CustomError>  & {
+  cache: Cache<any>;
 };
 
 export const genericFetcherPropsMeta: PropMetas<GenericFetcherProps> = {
@@ -33,12 +52,15 @@ export const genericFetcherPropsMeta: PropMetas<GenericFetcherProps> = {
     displayName: "Data name",
     defaultValue: "fetchedData",
     description: "Variable name to store the fetched data in",
+    invariantable: true,
   },
   errorName: {
     type: "string",
     displayName: "Error name",
-    defaultValue: "fetchError",
+    defaultValue: "error",
     description: "Variable name to store the fetch error in",
+    advanced: true,
+    invariantable: true,
   },
   previewSpinner: {
     type: "boolean",
@@ -56,10 +78,373 @@ export const genericFetcherPropsMeta: PropMetas<GenericFetcherProps> = {
     description:
       "When set, CMS Data Loader will not layout its children; instead, the layout set on its parent element will be used. Useful if you want to set flex gap or control container tag type.",
     defaultValue: false,
+    advanced: true,
+  },
+  useMutation: {
+    type: "boolean",
+    displayName: "Use mutation",
+    description:
+      "Whether to use a mutation instead of a query. Useful for POST, PUT, DELETE, etc.",
+    defaultValue: false,
+  },
+  disabled: {
+    type: "boolean",
+    displayName: "Disabled",
+    description: "Whether to disable the fetcher",
+    defaultValue: false,
+  },
+  onResultChange: {
+    type: "eventHandler",
+    argTypes: [
+      {
+        name: "result",
+        type: "object",
+      },
+    ],
+    description:
+      "Event handler to run when the fetch result is changing. The handler receives the fetch result as an argument.",
+  },
+  suspense: {
+    type: "boolean",
+    description:
+      "Whether to enable Suspense mode. When enabled, the fetcher will throw a Promise that can be caught by a Suspense boundary.",
+    defaultValue: false,
+    advanced: true,
+    invariantable: true,
+  },
+  fetcher: {
+    type: "code",
+    lang: "javascript",
+    description:
+      "Custom fetcher function. If not specified, the default fetcher will be used.",
+    advanced: true,
+    invariantable: true,
+  },
+  revalidateIfStale: {
+    type: "boolean",
+    description:
+      "Whether to revalidate the data if it's stale (not fresh). By default, SWR will only revalidate the data when it's re-rendered.",
+    defaultValue: false,
+    advanced: true,
+    invariantable: true,
+  },
+  revalidateOnMount: {
+    type: "boolean",
+    description:
+      "Whether to revalidate the data when the component is mounted.",
+    defaultValue: true,
+    advanced: true,
+    invariantable: true,
+  },
+  revalidateOnFocus: {
+    type: "boolean",
+    description:
+      "Whether to revalidate the data when the browser window regains focus.",
+    defaultValue: false,
+    advanced: true,
+    invariantable: true,
+  },
+  revalidateOnReconnect: {
+    type: "boolean",
+    description:
+      "Whether to revalidate the data when the browser regains network connection.",
+    defaultValue: false,
+    advanced: true,
+    invariantable: true,
+  },
+  refreshInterval: {
+    type: "number",
+    description:
+      "The polling interval (in milliseconds) when using the default fetcher.",
+    defaultValue: 0,
+    advanced: true,
+    invariantable: true,
+  },
+  refreshWhenHidden: {
+    type: "boolean",
+    description:
+      "Whether to revalidate the data when the browser window is hidden.",
+    defaultValue: false,
+    advanced: true,
+    invariantable: true,
+  },
+  refreshWhenOffline: {
+    type: "boolean",
+    description:
+      "Whether to revalidate the data when the browser regains network connection.",
+    defaultValue: false,
+    advanced: true,
+    invariantable: true,
+  },
+  shouldRetryOnError: {
+    type: "boolean",
+    description:
+      "Whether to retry when a request fails (after the onError handler is called).",
+    defaultValue: true,
+    advanced: true,
+    invariantable: true,
+  },
+  dedupingInterval: {
+    type: "number",
+    description:
+      "The interval (in milliseconds) to dedupe requests. When a request is deduped, the previously created request will be returned.",
+    defaultValue: 2000,
+    advanced: true,
+    invariantable: true,
+  },
+  focusThrottleInterval: {
+    type: "number",
+    description:
+      "The interval (in milliseconds) to throttle the focus revalidation.",
+    defaultValue: 5000,
+    advanced: true,
+    invariantable: true,
+  },
+  loadingTimeout: {
+    type: "number",
+    description:
+      "The time (in milliseconds) before triggering the onLoadingSlow event.",
+    defaultValue: 3000,
+    advanced: true,
+    invariantable: true,
+  },
+  errorRetryInterval: {
+    type: "number",
+    description:
+      "The interval (in milliseconds) to retry when a request fails.",
+    defaultValue: 5000,
+    advanced: true,
+    invariantable: true,
+  },
+  errorRetryCount: {
+    type: "number",
+    description:
+      "The maximum number of retries when a request fails. Set to 0 to disable retrying.",
+    defaultValue: 3,
+    advanced: true,
+  },
+  fallback: {
+    type: "object",
+    description:
+      "The fallback data to return while the request is still pending.",
+    defaultValue: {},
+    advanced: true,
+  },
+  fallbackData: {
+    type: "object",
+    description:
+      "The initial data to return while the request is still pending.",
+    defaultValue: {},
+    advanced: true,
+  },
+  keepPreviousData: {
+    type: "boolean",
+    description:
+      "Whether to keep the previous data when the request is revalidated.",
+    defaultValue: false,
+    advanced: true,
+    invariantable: true,
+  },
+  onLoadingSlow: {
+    type: "eventHandler",
+    argTypes: [
+      {
+        name: "key",
+        type: "string",
+      },
+      {
+        name: "config",
+        type: "object",
+      },
+    ],
+    description:
+      "Event handler to run when a request takes too long to load. The handler receives the query key and the fetch config as arguments.",
+    advanced: true,
+    invariantable: true,
+  },
+  onSuccess: {
+    type: "eventHandler",
+    argTypes: [
+      {
+        name: "data",
+        type: "object",
+      },
+      {
+        name: "key",
+        type: "string",
+      },
+      {
+        name: "config",
+        type: "object",
+      },
+    ],
+    description:
+      "Event handler to run when the fetch is successful. The handler receives the fetched data, the query key, and the fetch config as arguments.",
+  },
+  onError: {
+    type: "eventHandler",
+    argTypes: [
+      {
+        name: "error",
+        type: "object",
+      },
+      {
+        name: "key",
+        type: "string",
+      },
+      {
+        name: "config",
+        type: "object",
+      },
+    ],
+    description:
+      "Event handler to run when the fetch fails. The handler receives the error, the query key, and the fetch config as arguments.",
+  },
+  onErrorRetry: {
+    type: "eventHandler",
+    argTypes: [
+      {
+        name: "error",
+        type: "object",
+      },
+      {
+        name: "key",
+        type: "string",
+      },
+      {
+        name: "config",
+        type: "object",
+      },
+      {
+        name: "revalidate",
+        type: "exprEditor",
+      },
+      {
+        name: "revalidateOps",
+        type: "object",
+      },
+    ],
+    description:
+      "Event handler to run when the fetch fails and should retry. The handler receives the error, the query key, the fetch config, the revalidate function, and the revalidate options as arguments.",
+    advanced: true,
+    invariantable: true,
+  },
+  onDiscarded: {
+    type: "eventHandler",
+    argTypes: [
+      {
+        name: "key",
+        type: "string",
+      },
+    ],
+    description: "Event handler to run when a request is ignored.",
+    advanced: true,
+    invariantable: true,
+  },
+  compare: {
+    type: "exprEditor",
+    description:
+      "Comparison function used to detect when returned data has changed. The handler receives the previous data and the current data as arguments.",
+    advanced: true,
+    invariantable: true,
+  },
+  isPaused: {
+    type: "exprEditor",
+    description:
+      "Function to detect whether pause revalidations. The handler receives no arguments.",
+    advanced: true,
+    invariantable: true,
+  },
+  use: {
+    type: "array",
+    description: "Array of middleware functions.",
+    advanced: true,
+    invariantable: true,
   },
 };
 
-export function GenericFetcherShell<T>({
+export const genericFetcherStates: ComponentMeta<GenericFetcherProps>["states"] =
+  {
+    result: {
+      type: "readonly",
+      initVal: {},
+      variableType: "object",
+      onChangeProp: "onResultChange",
+    },
+  };
+
+type SWRHooksProps = {
+  key: string;
+  fetcher: () => Promise<any>;
+  config: FetcherOptions;
+  disabled?: boolean;
+  useMutation?: boolean;
+};
+
+function useSWRHooks({
+  key,
+  fetcher,
+  config,
+  disabled = false,
+  useMutation = false,
+}: SWRHooksProps) {
+  const configDefault = useSWRConfig();
+  
+  // Used in plasmic prepass and should override the default config
+  const plasmicConfig = usePlasmicDataConfig();
+  const {suspense, fallback = {}, fallbackData = {}, cache} = plasmicConfig;
+  
+  // We need to preserve the use middlewares array to support SWR DevTools https://swr-devtools.vercel.app/ 
+  const defaltUse = configDefault.use || [];
+  const configUse = config.use || [];
+  const use = [...defaltUse, ...configUse];
+  
+  config = clearOptionValues({ 
+    ...configDefault, 
+    ...config,
+    suspense,
+    cache: cache as any,
+    fallback: Object.assign(fallback, config.fallback || {}),
+    // Allow overriding the fallbackData
+    fallbackData: Object.keys(config.fallbackData || {}).length ? Object.assign(fallbackData, config.fallbackData) : undefined,
+    use
+  });
+
+  // We can't use useSWR here because it breaks the Plasmic prepass
+  // See: https://github.com/vercel/swr/issues/1832#issuecomment-1354106993
+  const { data, error, isLoading, isValidating, mutate } = useMutablePlasmicQueryData(
+    !disabled && !useMutation ? key : null,
+    fetcher,
+    config as any
+  );
+
+  const {
+    isMutating,
+    reset,
+    trigger,
+    data: mutationData,
+    error: mutationError,
+  } = useSWRMutation(
+    !disabled && useMutation ? key : null,
+    fetcher,
+    config as SWRMutationConfiguration<any, CustomError>
+  );
+
+  const result = {
+    data: useMutation ? mutationData : data,
+    error: useMutation ? mutationError : error,
+    isLoading,
+    isValidating,
+    mutate,
+    isMutating,
+    reset,
+    trigger,
+  } as FetcherResult;
+
+  return { result };
+}
+
+export function GenericFetcherShell({
   result,
   children,
   loadingDisplay,
@@ -70,29 +455,31 @@ export function GenericFetcherShell<T>({
   errorName,
   noLayout,
   className,
-}: GenericFetcherProps & {
-  result: { data?: T; error?: Error; isLoading?: boolean };
-}) {
+  onResultChange,
+}: GenericFetcherProps & { result: FetcherResult }) {
   const inEditor = !!usePlasmicCanvasContext();
-  if (
-    (inEditor && previewSpinner) ||
-    (!("error" in result) && !("data" in result))
-  ) {
+
+  const { isLoading, isValidating, isMutating } = result;
+  React.useEffect(() => {
+    onResultChange?.(result);
+  }, [isLoading, isValidating, isMutating]);
+
+  if ((inEditor && previewSpinner) || isValidating || isMutating || !result.data) {
     return <>{loadingDisplay ?? null}</>;
-  } else if ((inEditor && previewErrorDisplay) || "error" in result) {
+  }
+  if ((inEditor && previewErrorDisplay) || result.error) {
     return (
       <DataProvider name={errorName} data={result.error}>
         {errorDisplay ?? null}
       </DataProvider>
     );
-  } else {
-    const content = (
-      <DataProvider name={dataName} data={result.data}>
-        {children}
-      </DataProvider>
-    );
-    return noLayout ? content : <div className={className}>{content}</div>;
   }
+  const content = (
+    <DataProvider name={dataName} data={result.data}>
+      {children}
+    </DataProvider>
+  );
+  return noLayout ? content : <div className={className}>{content}</div>;
 }
 
 export interface FetchProps {
@@ -126,7 +513,7 @@ async function performFetch({ url, method, body, headers }: FetchProps) {
   try {
     json = JSON.parse(text);
   } catch (e) {
-    json = { text };
+    // Ignore
   }
 
   // @see https://swr.vercel.app/docs/error-handling
@@ -147,13 +534,94 @@ export interface DataFetcherProps extends FetchProps, GenericFetcherProps {
   queryKey?: string;
 }
 
+function clearOptionValues(options: FetcherOptions) {
+  return Object.fromEntries(
+    Object.entries(options).filter(([_, v]) => v !== undefined)
+  ) as FetcherOptions;
+}
+
+function getFetcherOptions(props: DataFetcherProps): FetcherOptions {
+  const {
+    suspense,
+    fetcher,
+    revalidateIfStale,
+    revalidateOnMount,
+    revalidateOnFocus,
+    revalidateOnReconnect,
+    refreshInterval,
+    refreshWhenHidden,
+    refreshWhenOffline,
+    shouldRetryOnError,
+    dedupingInterval,
+    focusThrottleInterval,
+    loadingTimeout,
+    errorRetryInterval,
+    errorRetryCount,
+    fallback,
+    fallbackData,
+    keepPreviousData,
+    onLoadingSlow,
+    onSuccess,
+    onError,
+    onErrorRetry,
+    onDiscarded,
+    compare,
+    isPaused,
+    use,
+  } = props;
+
+  const options = {
+    suspense,
+    fetcher,
+    revalidateIfStale,
+    revalidateOnMount,
+    revalidateOnFocus,
+    revalidateOnReconnect,
+    refreshInterval,
+    refreshWhenHidden,
+    refreshWhenOffline,
+    shouldRetryOnError,
+    dedupingInterval,
+    focusThrottleInterval,
+    loadingTimeout,
+    errorRetryInterval,
+    errorRetryCount,
+    fallback,
+    fallbackData,
+    keepPreviousData,
+    onLoadingSlow,
+    onSuccess,
+    onError,
+    onErrorRetry,
+    onDiscarded,
+    compare,
+    isPaused,
+    use,
+  };
+
+  return clearOptionValues(options as FetcherOptions)
+}
+
 export function DataFetcher(props: DataFetcherProps) {
-  const { url, method, body, headers, queryKey } = props;
+  const { url, method, body, headers, queryKey, disabled, useMutation } = props;
+
   const fetchProps: FetchProps = { url, method, body, headers };
-  const result = usePlasmicQueryData(
-    queryKey || JSON.stringify({ type: "DataFetcher", ...fetchProps }),
-    () => performFetch(fetchProps)
-  );
+
+  const key =
+    queryKey || JSON.stringify({ type: "DataFetcher", ...fetchProps });
+
+  const fetcher = () => performFetch(fetchProps);
+
+  const config = getFetcherOptions(props);
+
+  const { result } = useSWRHooks({
+    key,
+    fetcher,
+    config,
+    disabled,
+    useMutation,
+  });
+
   return <GenericFetcherShell result={result} {...props} />;
 }
 
@@ -207,6 +675,7 @@ export const dataFetcherMeta: ComponentMeta<DataFetcherProps> = {
   providesData: true,
   description:
     "These fetches may be run client-side (from the browser). Use [Data Queries](https://docs.plasmic.app/learn/http-api-integration/) for authenticated queries or CORS.",
+  states: genericFetcherStates,
   props: {
     ...(mkFetchProps(
       "https://api.github.com/users/plasmicapp/repos",
@@ -247,17 +716,38 @@ export interface GraphqlFetcherProps
 }
 
 export function GraphqlFetcher(props: GraphqlFetcherProps) {
-  const { query, url, method, headers, queryKey, varOverrides } = props;
+  const {
+    query,
+    url,
+    method,
+    headers,
+    queryKey,
+    varOverrides,
+    disabled,
+    useMutation,
+  } = props;
   const fetchProps: FetchProps = {
     body: { ...query, variables: { ...query?.variables, ...varOverrides } },
     url,
     method,
     headers,
   };
-  const result = usePlasmicQueryData(
-    queryKey || JSON.stringify({ type: "GraphqlFetcher", ...fetchProps }),
-    () => performFetch(fetchProps)
-  );
+
+  const key =
+    queryKey || JSON.stringify({ type: "DataFetcher", ...fetchProps });
+
+  const fetcher = () => performFetch(fetchProps);
+
+  const config = getFetcherOptions(props);
+
+  const { result } = useSWRHooks({
+    key,
+    fetcher,
+    config,
+    disabled,
+    useMutation,
+  });
+
   return <GenericFetcherShell result={result} {...props} />;
 }
 
@@ -267,6 +757,7 @@ export const graphqlFetcherMeta: ComponentMeta<GraphqlFetcherProps> = {
   importName: "GraphqlFetcher",
   importPath: "@plasmicpkgs/plasmic-query",
   providesData: true,
+  states: genericFetcherStates,
   props: (() => {
     const gqlMetas: PropMetas<GraphqlFetcherProps> = {
       query: {
@@ -276,15 +767,15 @@ export const graphqlFetcherMeta: ComponentMeta<GraphqlFetcherProps> = {
         endpoint: (props) => props.url ?? "",
         defaultValue: {
           query: `query MyQuery($name: String) {
-  characters(filter: {name: $name}) {
-    results {
-      name
-      species
-      image
-    }
-  }
-}
-`,
+                    characters(filter: {name: $name}) {
+                      results {
+                        name
+                        species
+                        image
+                      }
+                    }
+                  }
+                  `,
           variables: {
             name: "Rick Sanchez",
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -31302,18 +31302,18 @@ swell-js@^3.13.0:
     fast-case "^1.7.0"
     qs "^6.11.1"
 
-swr@^1.0.0, swr@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
-  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
-
-swr@^2.0.0:
+swr@2.2.4, swr@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.4.tgz#03ec4c56019902fbdc904d78544bd7a9a6fa3f07"
   integrity sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==
   dependencies:
     client-only "^0.0.1"
     use-sync-external-store "^1.2.0"
+
+swr@^1.0.0, swr@^1.2.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
+  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
 
 symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
**Motivation:** 

Current backend integrations sometimes have unpredictable load times, generally much longer than fetching directly from the endpoint server without going through Plasmic servers. As a workaround, we can use a browser fetch API. However, it has several problems, making it difficult to use in many cases. 

**Problems with Browser Fetch API:**

1. It is currently impossible to configure the underlying SWR directly for revalidation on focus, on mount, on reconnect, etc.
2. Managing the cache is challenging. There is no clear way to access the default query key and use it for mutation. Or to revalidate on page revisit when data was mutated on another page, as all fetched data is now immutable by design.
3. Manually calling mutation requests, for example, for form submission, is very difficult and requires workarounds like conditional rendering.
4. The only way to get data and handle fetch states is by using slots.
5. It is not possible to access error data, such as request status code and additional information from the server response.

**Suggested Solutions:**

1. Make certain SWR configuration options available from the Studio.
2. Use mutable SWR requests that can be fully configured from the Studio.
3. Make use of the useSWRMutation hook available from the second major version of the SWR library.
4. Provide extended error data like status codes and info.
5. Add a readable component state that can be accessed from other components on the page and allows easy access to fetch states, data, errors, and some methods like mutate and trigger.
6. Add onError, onSuccess, and other eventHandlers, allowing convenient component integrations besides using slots.

**Known Caveats:**

The SWR Library from the 2nd major version mainly disallows using suspense on the server side, breaking the current Plasmic SSR prepass mechanism. See [this GitHub issue](https://github.com/vercel/swr/issues/1832#issuecomment-1354106993) for more details.

Therefore, we continue using the existing [useMutablePlasmicQueryData](https://github.com/plasmicapp/plasmic/blob/master/packages/query/src/query-data.tsx#L91) for fetching data, which is still based on the prior SWR version and supports react-ssr-prepass. For manual mutation requests, the 2nd version of SWR is used.

All this makes it harder to provide and use the correct SWR configuration, leading to potential inconsistencies with caching, especially when using custom cache providers, suspense, fallback, and fallbackData properties.

![image](https://github.com/plasmicapp/plasmic/assets/2431976/b79b3481-c2a6-4e3c-a93c-02af897c1d4e)

![image](https://github.com/plasmicapp/plasmic/assets/2431976/db0dd70c-1385-46cf-885e-56ad2a179fe4)

![image](https://github.com/plasmicapp/plasmic/assets/2431976/1ded13ae-7f98-4c4d-aaa6-ddf3db1aa669)




