### PR TITLE
Reduce bundle size of @plasmicpkgs/react-slick #104

### DIFF
--- a/plasmicpkgs/react-slick/src/index.tsx
+++ b/plasmicpkgs/react-slick/src/index.tsx
@@ -4,7 +4,11 @@ import registerComponent, {
   ComponentHelpers,
   ComponentMeta,
 } from "@plasmicapp/host/registerComponent";
-import { Button } from "antd";
+// import { Button } from "antd";
+
+
+
+
 import React, {
   ChangeEvent,
   forwardRef,
@@ -210,7 +214,7 @@ export function registerSlider(loader?: {
 
   function NavigateSlides({ componentProps, studioOps }: ActionProps<any>) {
     const { dotCount, currentDotIndex } = getSlideInfo(componentProps);
-
+  
     return (
       <div
         style={{
@@ -221,19 +225,17 @@ export function registerSlider(loader?: {
           justifyContent: "space-between",
         }}
       >
-        <Button
+        <button
           style={{ width: "100%" }}
           onClick={() => {
             const prevSlide =
-              currentDotIndex === 0
-                ? dotCount - 1
-                : (currentDotIndex - 1) % dotCount;
+              currentDotIndex === 0 ? dotCount - 1 : (currentDotIndex - 1) % dotCount;
             studioOps.updateStates({ currentSlide: prevSlide });
           }}
         >
           Prev slide
-        </Button>
-        <Button
+        </button>
+        <button
           style={{ width: "100%" }}
           onClick={() => {
             const nextSlide = (currentDotIndex + 1) % dotCount;
@@ -241,11 +243,11 @@ export function registerSlider(loader?: {
           }}
         >
           Next slide
-        </Button>
+        </button>
       </div>
     );
   }
-
+  
   function OutlineMessage() {
     return <div>* To re-arrange slides, use the Outline panel</div>;
   }


### PR DESCRIPTION
This code snippet is a modified version of a slider component designed to reduce dependencies and potentially decrease the bundle size. The primary change involves replacing the usage of `antd` library's `Button` component with native HTML buttons within the `NavigateSlides` component.

The `NavigateSlides` component offers functionality for navigating through slides in a carousel-like display. The previous usage of `antd`'s buttons has been replaced with standard HTML buttons, ensuring the component's functionality remains intact while removing the dependency on an external library.

This modification aims to optimize the codebase by utilizing native HTML elements, potentially reducing the overall size of the application bundle by eliminating the need for the `antd` library's button component.