### PR TITLE
feat(radix-ui/tooltip): allow to customize delay duration

### DIFF
--- a/plasmicpkgs/radix-ui/src/tooltip.tsx
+++ b/plasmicpkgs/radix-ui/src/tooltip.tsx
@@ -111,6 +111,10 @@ export function registerTooltip(PLASMIC?: Registerable) {
           ...popoverProps.side,
           defaultValueHint: "top",
         },
+        delayDuration: {
+          type: "number",
+          defaultValueHint: 700
+        },
       },
       overlay: {
         type: "slot",


### PR DESCRIPTION
Currently the default is to show the tooltip 700ms after a user hovers the tooltip trigger, which may be a too long wait in some scenarios. ( https://www.radix-ui.com/primitives/docs/components/tooltip )