### PR TITLE
@plasmicapp/nextjs-app-router - use cross-spawn to make it work on windows

### DIFF
--- a/packages/nextjs-app-router/package.json
+++ b/packages/nextjs-app-router/package.json
@@ -30,7 +30,8 @@
     "fkill": "^8.1.0",
     "get-port": "^7.0.0",
     "node-html-parser": "^6.1.5",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "cross-spawn": "^7.0.3"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/nextjs-app-router/src/with-dev-server.mts
+++ b/packages/nextjs-app-router/src/with-dev-server.mts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import cp from "child_process";
+import { spawn } from "cross-spawn";
+import { type ChildProcess } from "child_process";
 import fkill from "fkill";
 import getPort from "get-port";
 import process from "process";
@@ -18,7 +19,7 @@ async function startDevServer(
     `Plasmic: starting prepass dev server at http://localhost:${port} via "npm run ${command}"...`
   );
 
-  const devServerProcess = cp.spawn(`npm`, ["run", command], {
+  const devServerProcess = spawn(`npm`, ["run", command], {
     env: {
       PLASMIC_PREPASS_SERVER: "true",
       ...process.env,
@@ -27,7 +28,7 @@ async function startDevServer(
   });
 
   let started = false;
-  return new Promise<cp.ChildProcess>((resolve, reject) => {
+  return new Promise<ChildProcess>((resolve, reject) => {
     devServerProcess.stdout?.on("data", (data) => {
       if (!started && data.toString().toLowerCase().includes("ready")) {
         started = true;
@@ -82,7 +83,7 @@ async function main() {
 
   const command = argv._.map((x) => `${x}`);
   console.log(`Plasmic: Running command: ${command.join(" ")}`);
-  const commandProcess = cp.spawn(command[0], command.slice(1), {
+  const commandProcess = spawn(command[0], command.slice(1), {
     env: {
       ...process.env,
       PLASMIC_PREPASS_HOST: `http://localhost:${port}`,


### PR DESCRIPTION
Hi there,

the `with-plasmic-prepass` cli currently does not work on windows, because `npm` cannot be spawned as a child process (without either using shell or spawning `npm.bat`)

using `cross-spawn` would fix that.