### PR TITLE
atnd5 Menu component - add support for default selected keys

### DIFF
--- a/plasmicpkgs/antd5/src/registerMenu.tsx
+++ b/plasmicpkgs/antd5/src/registerMenu.tsx
@@ -108,6 +108,11 @@ export function registerMenu(loader?: Registerable) {
         defaultValueHint: "hover",
         advanced: true,
       },
+      defaultSelectedKeys: {
+        type: 'array',
+        description: 'An array of Menu Item/s that will be selected when this component first loads, eg ["home", "about"]. Each item in the array should be one of the unique keys set in nested Menu Item component props. Useful when using the Menu component to build a website navigation bar.',
+        advanced: true,
+      },
       //   menuScopeClassName: {
       //     type: "styleScopeClass",
       //     scopeName: "menu",


### PR DESCRIPTION
**CONTEXT**

The Antd Menu component is well-suited for building the navigation menu for a website or app being created in Plasmic studio. 

Of course, when building a website navigation bar, it's important to show the user what page they are currently on 
![image](https://github.com/user-attachments/assets/ad3bf9ec-d6aa-4872-9520-7f4fda975001)

The [default selected keys prop of the antd menu](https://ant.design/components/menu#menu) component allows specification of the default (initially selected) menu items.

**PROBLEM**

The existing Plasmic code component registratoin for antd5 Menu component does not allow the user to specify the default selected keys prop of the Antd Menu component. 

**SOLUTION**
This PR adds support for the missing prop.

This allows Plasmic studio users to flexibly control which menu item/s are selected when the component first loads.

In the context of creating an app/website navigation menu, here is an example of how this new prop can be used effectively:

https://github.com/user-attachments/assets/2bd19e25-bb49-4c00-9295-9445dd30d56a

