### PR TITLE
implemented CMS entry copy features

### DIFF
--- a/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
+++ b/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
@@ -692,6 +692,7 @@ function CmsEntryDetailsForm_(
                   identifier: inputCopyIdentifier,
                 });
                 if (copiedRow) {
+                  setShowCopyModal(false);
                   await message.success({
                     key: "copy-message",
                     content: (

--- a/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
+++ b/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
@@ -185,7 +185,6 @@ function CmsEntryDetailsForm_(
   const [hasUnpublishedChanges, setHasUnpublishedChanges] = React.useState(
     !!row?.draftData
   );
-  // Hyuna
   const [showCopyModal, setShowCopyModal] = React.useState(false);
   const [inputCopyIdentifier, setInputCopyIdentifier] = React.useState("");
 

--- a/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
+++ b/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
@@ -606,7 +606,7 @@ function CmsEntryDetailsForm_(
                   }}
                   disabled={isSaving || isPublishing}
                 >
-                  <span>Copy entry</span>
+                  <span>Duplicate entry</span>
                 </Menu.Item>
                 <Menu.Divider />
                 <Menu.Item
@@ -668,7 +668,7 @@ function CmsEntryDetailsForm_(
         >
           <Form.Item name="copyIdentifier">
             <span>
-              {`Duplicate the CMS entry with identifier "${inputCopyIdentifier}"?`}
+              {`Duplicate the CMS entry with identifier "${row.identifier}"?`}
               <br />
               {`This will create an unpublished copy of the entry and all its data.`}
             </span>

--- a/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
+++ b/platform/wab/src/wab/client/components/cms/CmsEntryDetails.tsx
@@ -608,7 +608,6 @@ function CmsEntryDetailsForm_(
                 >
                   <span>Duplicate entry</span>
                 </Menu.Item>
-                <Menu.Divider />
                 <Menu.Item
                   key="delete"
                   onClick={async () => {

--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -61,6 +61,7 @@ import {
 import {
   cloneDatabase,
   cmsFileUpload,
+  copyRow,
   createDatabase,
   createRows,
   createTable,
@@ -826,6 +827,8 @@ export function addCmsEditorRoutes(app: express.Application) {
   app.get("/api/v1/cmse/rows/:rowId/revisions", withNext(listRowRevisions));
   app.put("/api/v1/cmse/rows/:rowId", withNext(updateRow));
   app.delete("/api/v1/cmse/rows/:rowId", withNext(deleteRow));
+  // Hyuna
+  app.post("/api/v1/cmse/rows/:rowId/copy", withNext(copyRow));
   app.get("/api/v1/cmse/row-revisions/:revId", withNext(getRowRevision));
 
   app.post(

--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -827,7 +827,6 @@ export function addCmsEditorRoutes(app: express.Application) {
   app.get("/api/v1/cmse/rows/:rowId/revisions", withNext(listRowRevisions));
   app.put("/api/v1/cmse/rows/:rowId", withNext(updateRow));
   app.delete("/api/v1/cmse/rows/:rowId", withNext(deleteRow));
-  // Hyuna
   app.post("/api/v1/cmse/rows/:rowId/copy", withNext(copyRow));
   app.get("/api/v1/cmse/row-revisions/:revId", withNext(getRowRevision));
 

--- a/platform/wab/src/wab/server/db/DbMgr.ts
+++ b/platform/wab/src/wab/server/db/DbMgr.ts
@@ -274,7 +274,6 @@ import {
   UpdateResult,
 } from "typeorm";
 import * as uuid from "uuid";
-// Hyuna
 
 import { getLowestCommonAncestor } from "@/wab/shared/site-diffs/commit-graph";
 
@@ -7343,7 +7342,6 @@ export class DbMgr implements MigrationDbMgr {
     await this.entMgr.save(row);
   }
 
-  // Hyuna
   async copyCmsRow(
     tableId: CmsTableId,
     rowId: CmsRowId,

--- a/platform/wab/src/wab/server/db/DbMgr.ts
+++ b/platform/wab/src/wab/server/db/DbMgr.ts
@@ -7347,17 +7347,14 @@ export class DbMgr implements MigrationDbMgr {
     rowId: CmsRowId,
     opts: {
       identifier?: string;
-      data?: Dict<Dict<unknown>>;
-      draftData?: Dict<Dict<unknown>> | null;
     }
   ) {
     await this.checkCmsRowPerms(rowId, "content");
     const row = await this.getCmsRowById(rowId);
-    opts = {
-      identifier: opts.identifier !== "" ? opts.identifier : undefined,
+    const copiedRow = await this.createCmsRow(tableId, {
+      identifier: opts.identifier || undefined,
       draftData: row.draftData || row.data,
-    };
-    const copiedRow = await this.createCmsRow(tableId, opts);
+    });
     return await this.entMgr.save(copiedRow);
   }
 

--- a/platform/wab/src/wab/server/db/DbMgr.ts
+++ b/platform/wab/src/wab/server/db/DbMgr.ts
@@ -274,6 +274,7 @@ import {
   UpdateResult,
 } from "typeorm";
 import * as uuid from "uuid";
+// Hyuna
 
 import { getLowestCommonAncestor } from "@/wab/shared/site-diffs/commit-graph";
 
@@ -7340,6 +7341,26 @@ export class DbMgr implements MigrationDbMgr {
     const row = await this.getCmsRowById(rowId);
     Object.assign(row, this.stampDelete());
     await this.entMgr.save(row);
+  }
+
+  // Hyuna
+  async copyCmsRow(
+    tableId: CmsTableId,
+    rowId: CmsRowId,
+    opts: {
+      identifier?: string;
+      data?: Dict<Dict<unknown>>;
+      draftData?: Dict<Dict<unknown>> | null;
+    }
+  ) {
+    await this.checkCmsRowPerms(rowId, "content");
+    const row = await this.getCmsRowById(rowId);
+    opts = {
+      identifier: opts.identifier !== "" ? opts.identifier : undefined,
+      draftData: row.draftData || row.data,
+    };
+    const copiedRow = await this.createCmsRow(tableId, opts);
+    return await this.entMgr.save(copiedRow);
   }
 
   // TODO We are always querying just the default locale.

--- a/platform/wab/src/wab/server/routes/cmse.ts
+++ b/platform/wab/src/wab/server/routes/cmse.ts
@@ -269,6 +269,27 @@ export async function deleteRow(req: Request, res: Response) {
   res.json({});
 }
 
+// Hyuna
+export async function copyRow(req: Request, res: Response) {
+  const mgr = userDbMgr(req);
+  const row = await mgr.getCmsRowById(req.params.rowId as CmsRowId);
+  userAnalytics(req).track({
+    event: "Copy cms row",
+    properties: {
+      rowId: row.id as CmsRowId,
+      tableId: row.tableId,
+      tableName: row.table?.name,
+      databaseId: row.table?.databaseId,
+    },
+  });
+  const copiedRow = await mgr.copyCmsRow(
+    row.tableId as CmsTableId,
+    req.params.rowId as CmsRowId,
+    req.body
+  );
+  res.json(copiedRow);
+}
+
 export async function updateRow(req: Request, res: Response) {
   const mgr = userDbMgr(req);
   const row = await mgr.updateCmsRow(req.params.rowId as CmsRowId, req.body);

--- a/platform/wab/src/wab/server/routes/cmse.ts
+++ b/platform/wab/src/wab/server/routes/cmse.ts
@@ -269,7 +269,6 @@ export async function deleteRow(req: Request, res: Response) {
   res.json({});
 }
 
-// Hyuna
 export async function copyRow(req: Request, res: Response) {
   const mgr = userDbMgr(req);
   const row = await mgr.getCmsRowById(req.params.rowId as CmsRowId);

--- a/platform/wab/src/wab/shared/SharedApi.ts
+++ b/platform/wab/src/wab/shared/SharedApi.ts
@@ -1724,6 +1724,15 @@ export abstract class SharedApi {
     return (await this.put(`/cmse/rows/${rowId}`, opts)) as ApiCmseRow;
   }
 
+  async copyCmsRow(
+    rowId: CmsRowId,
+    opts: {
+      identifier: string;
+    }
+  ) {
+    return (await this.post(`/cmse/rows/${rowId}/copy`, opts)) as ApiCmseRow;
+  }
+
   async deleteCmsRow(rowId: CmsRowId) {
     return await this.delete(`/cmse/rows/${rowId}`);
   }


### PR DESCRIPTION
Created 'Copy Entry' menu item.

When a user mouses over 'Copy Entry', 
- when the entry is published, a tooltip appears with 'Creates an unpublished copy with the published data'.
- when the entry is unpublished, a tooltip appears with 'Creates a copy with draft data'.

When a user clicks 'Copy Entry', they see a prompt that asks for the new copy's title.
The default value of the input is
- when the original entry has no title, ''.
- when the original entry has a title, 'Copy of [title of original entry]'.
They can copy without a title.

When a user clicks 'Copy' in a prompt, prompt disappears and they see a message 'Copying...',
and after copy is completed, they see a message 'Copied'.
As the message disappears, the new copy is selected in the entry list.