### PR TITLE
fix(DataProvider): don't create new context value on every render

### DIFF
--- a/packages/host/src/data.tsx
+++ b/packages/host/src/data.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactElement,
   ReactNode,
   useContext,
+  useMemo,
 } from "react";
 import { tuple } from "./common";
 
@@ -90,22 +91,25 @@ export function DataProvider({
   label,
   children,
 }: DataProviderProps) {
-  const existingEnv = useDataEnv() ?? {};
-  if (!name) {
+  const parentContext = useDataEnv();
+  const childContext = useMemo(() => {
+    if (!name) {
+      return parentContext;
+    }
+    return {
+      ...parentContext,
+      [name]: data,
+      [mkMetaName(name)]: mkMetaValue({ hidden, advanced, label }),
+    };
+  }, [parentContext, name, data, hidden, advanced, label]);
+
+  if (parentContext === childContext) {
     return <>{children}</>;
-  } else {
-    return (
-      <DataContext.Provider
-        value={{
-          ...existingEnv,
-          [name]: data,
-          [mkMetaName(name)]: mkMetaValue({ hidden, advanced, label }),
-        }}
-      >
-        {children}
-      </DataContext.Provider>
-    );
   }
+
+  return (
+    <DataContext.Provider value={childContext}>{children}</DataContext.Provider>
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes one of the problems spotted in https://forum.plasmic.app/t/optimizing-render-performance-support-for-react-memo-and-key-prop/9895/4 . Currently `DataProvider` passes a new object on every render to the `DataContext.Provider`. This causes a lot of components (that consume the context) to be needlessly rerendered.

See https://react.dev/reference/react/useContext#optimizing-re-renders-when-passing-objects-and-functions for more info.