### PR TITLE
fix(LoadingBoundary): don't render nothing on SSR

### DIFF
--- a/plasmicpkgs/plasmic-basic-components/src/LoadingBoundary.tsx
+++ b/plasmicpkgs/plasmic-basic-components/src/LoadingBoundary.tsx
@@ -21,14 +21,6 @@ if (reactMajorVersion < 18) {
 const enableLoadingBoundaryKey = "plasmicInternalEnableLoadingBoundary";
 const hasLoadingBoundaryKey = "plasmicInternalHasLoadingBoundary";
 
-function useIsClient() {
-  const [loaded, setLoaded] = useState(false);
-  useIsomorphicLayoutEffect(() => {
-    setLoaded(true);
-  }, []);
-  return loaded;
-}
-
 let hasWarnedDisabledLoadingBoundary = false;
 
 function warnDisabledLoadingBoundary() {
@@ -45,12 +37,7 @@ export function LoadingBoundary({
   forceLoading,
   loadingState,
 }: LoadingBoundaryProps) {
-  const isClient = useIsClient();
   const enableLoadingBoundary = !!useDataEnv()?.[enableLoadingBoundaryKey];
-
-  if (!isClient && !plasmicQuery.isPlasmicPrepass?.()) {
-    return null;
-  }
 
   if (forceLoading) {
     return <>{loadingState ?? null}</>;


### PR DESCRIPTION
For a reason unknown to me, `LoadingBoundary` currently renders nothing on an initial render. 

It renders the loading fallback or the actual content only after the component is mounted (which never happens on a server-side render). Why? 

1. I'd expect that on a server-side render the loading fallback is simply shown. (So that it looks the same as on the client's initial render.)
2. Moreover, if we're in a SSR prepass, we should also continue with the usual `<Suspense fallback={...}>{children}</Suspense>` render result. So that e.g. if there are any plasmic queries done inside of that loading boundary, the server awaits them, so that the queries data can be prefetched and added to the cached data, which will be later passed to the final server and client render payloads.

After doing this change, the above issues became fixed in our project (that uses next.js, swr and react-ssr-prepass).