### PR TITLE
Added Sorting by _id, _createdAt, and _updatedAt to CMS API Order Query

### DIFF
--- a/platform/wab/src/wab/server/db/DbMgr.ts
+++ b/platform/wab/src/wab/server/db/DbMgr.ts
@@ -7402,17 +7402,23 @@ export class DbMgr implements MigrationDbMgr {
     if (query.order) {
       for (const order of query.order) {
         const field = typeof order === "string" ? order : order.field;
+        const dir =
+          typeof order === "string"
+            ? "ASC"
+            : order.dir === "asc"
+            ? "ASC"
+            : "DESC";
         if (field in fieldToMeta) {
-          const dir =
-            typeof order === "string"
-              ? "ASC"
-              : order.dir === "asc"
-              ? "ASC"
-              : "DESC";
           builder = builder.addOrderBy(
             makeTypedFieldSql(fieldToMeta[field], opts),
             dir
           );
+        } else if (
+          field === "_id" ||
+          field === "_createdAt" ||
+          field === "_updatedAt"
+        ) {
+          builder = builder.addOrderBy(`"${field.replace("_", "")}"`, dir);
         }
       }
     } else {


### PR DESCRIPTION
Implements sorting for _id, _createdAt, and _updatedAt columns in the CMS API order query. Users can now specify one of these fields within the order parameter to sort results. 

<Query Examples>
{"order": "_createdAt"} 
{"order": [{"field":"_createdAt", "dir":"asc"}]}