### PR TITLE
feat: add hot reloading to docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
     build:
       context: .
       dockerfile: ./platform/wab/tools/docker-dev/Dockerfile
+    volumes:
+      # Mount your local code into the container
+      - .:/plasmic
+      # Use an anonymous volume to prevent local node_modules from overwriting the container's
+      - /plasmic/node_modules
+      - /plasmic/platform/wab/node_modules
     ports:
       - "3003:3003"
       - "3004:3004"
@@ -34,6 +40,8 @@ services:
       - WAB_DBNAME=plasmic-db
       - WAB_DBPASSWORD=SEKRET
       - NODE_ENV=development
+      # This environment variable makes file watching more reliable.
+      - CHOKIDAR_USEPOLLING=true
     tty: true
     stdin_open: true
 


### PR DESCRIPTION
# 🔧 Enable Hot Reloading in `plasmic-wab` Service with Docker Volume Mounts

## 📌 Summary

This PR updates the Docker configuration for the `plasmic-wab` service to support **hot reloading** during development. It introduces volume mounts and key environment tweaks to ensure a smooth local development experience without sacrificing container stability.

---

## ✅ Changes Introduced

### 1. **Mounted Project Directory for Hot Reloading**

```yaml
.:/plasmic
```

- Mounts the current host directory (`.`) to the container's `/plasmic` directory.
- Ensures **instant updates** inside the container when files are changed locally.
- Enables real-time development and live-reloading support.

---

### 2. **Anonymous Volumes for `node_modules`**

```yaml
/plasmic/node_modules
/plasmic/platform/wab/node_modules
```

- Prevents host `node_modules` from overwriting container-installed modules.
- Preserves the container’s environment-specific dependencies (e.g., Alpine Linux binaries).
- Ensures compatibility and avoids common issues with mismatched host/container dependencies.

---

### 3. **Polling-Based File Watching**

```env
CHOKIDAR_USEPOLLING=true
```

- Enables polling mode for file watching tools like **Chokidar**, **Nodemon**, and **Next.js**.
- Solves problems with file change detection in Docker, especially on non-Linux systems (e.g., macOS or Windows).
- More robust and reliable for development workflows in Dockerized environments.

---
