### PR TITLE
chore: bootstrap SOPS secrets helper and dev env vault

### DIFF
--- a/.github/actions/sops-setup/action.yml
+++ b/.github/actions/sops-setup/action.yml
@@ -1,0 +1,50 @@
+name: SOPS Setup
+inputs:
+  sops_age_key:
+    description: Age private key contents
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Write age key
+      shell: bash
+      run: |
+        mkdir -p ~/.config/age
+        echo "$SOPS_AGE_KEY" > ~/.config/age/key.txt
+        chmod 600 ~/.config/age/key.txt
+      env:
+        SOPS_AGE_KEY: ${{ inputs.sops_age_key }}
+    - name: Install sops
+      shell: bash
+      run: |
+        if command -v sops >/dev/null 2>&1; then exit 0; fi
+        if [ "$(uname -s)" = "Linux" ]; then
+          if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -y && sudo apt-get install -y -q sops || true
+          fi
+          if ! command -v sops >/dev/null 2>&1; then
+            VER="v3.10.2"
+            curl -fsSL -o sops "https://github.com/getsops/sops/releases/download/${VER}/sops-${VER}.linux.amd64"
+            chmod +x sops && sudo mv sops /usr/local/bin/sops
+          fi
+        else
+          if command -v brew >/dev/null 2>&1; then brew install sops; fi
+        fi
+        command -v sops && sops --version
+    - name: Decrypt repo vault to .env.local
+      shell: bash
+      run: |
+        if [ -f .secrets/dev.env.enc ]; then
+          sops -d --input-type dotenv --output-type dotenv .secrets/dev.env.enc > .env.local
+        else
+          : > .env.local
+        fi
+    - name: Export env to GITHUB_ENV
+      shell: bash
+      run: |
+        if [ -s .env.local ]; then
+          while IFS= read -r line; do
+            [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+            echo "$line" >> "$GITHUB_ENV"
+          done < <(grep -v '^#' .env.local | sed '/^$/d')
+        fi

--- a/.github/workflows/secrets_sops_smoke.yml
+++ b/.github/workflows/secrets_sops_smoke.yml
@@ -1,0 +1,20 @@
+name: Secrets SOPS Smoke
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: SOPS decrypt + export env
+        uses: ./.github/actions/sops-setup
+        with:
+          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
+      - name: Show env keys (masked)
+        run: |
+          if [ -s .env.local ]; then
+            echo "Keys in .env.local:" && awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/{print $1}' .env.local | sed -n '1,120p'
+          else
+            echo ".env.local is empty (expected if vault is a placeholder)."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ storybook-static/
 *.dec.*
 dist/
 docs/
+.secrets/*.key
+.secrets/*.tmp
+.env.local.*

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ storybook-static/
 # ignore decrypted yaml files by sops
 *.dec.*
 dist/
+docs/

--- a/.secrets/dev.env.enc
+++ b/.secrets/dev.env.enc
@@ -1,0 +1,7 @@
+# dev env
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzZGJackttQVBwZ1FQaUJB\nWDJYR3d5cDN4WVdkMUhIYWZqVzdpWWFGOGs0CmN2YVpta1c4SVpWUnZZb0lLVWZQ\nb3BINENxZzgvVjc4cDFPUmxoQ2V2d0kKLS0tIHh6VXA5eitBaDMvTUIvVjdEUitZ\nbTc0OUw2eElHUnJLd3cwbWg2bVJoZm8KNd4OWMDa6hDBRL1uKn8cSl2ZG7p9/CK2\nAYTcoZVOyaVdFBxKqw8yQ9KwCswfExgvmkyWSBpmBgqQIhb0LqgmiQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age133smdkygqrhj7w7rfmwq8fvt6da6xk5gec2lksshx3zr775k5vvqhflzt8
+sops_encrypted_regex=^(.*)$
+sops_lastmodified=2025-09-07T01:24:20Z
+sops_mac=ENC[AES256_GCM,data:Y4fXaEIclg4NjNUvAnVlnMSW6b3tVRLlASJRSSO1T77JrrCBLgjZK7TGNwwgrSerj9tqFo5cVM3plD4QFcTlcprQbsi7hY2ORHqeywayNYch3dvjQaPjqC3Osv7spKr2PpM92FxQt76eaj/bb5HUMbggh+9XV443NquUmiesNxE=,iv:OPo0jszzXVxmhOkZ6bNdj4U8Pmf2mPKJabar8+Z63sY=,tag:vHyjEbBqfNseUOSnZljrtg==,type:str]
+sops_version=3.10.2

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,4 @@
+creation_rules:
+  - path_regex: \.secrets\/.*\.env\.enc$
+    encrypted_regex: '^(.*)$'
+    age: "age133smdkygqrhj7w7rfmwq8fvt6da6xk5gec2lksshx3zr775k5vvqhflzt8"

--- a/README.md
+++ b/README.md
@@ -269,3 +269,17 @@ Thanks to all the people who make Plasmic!
 <a href="https://github.com/plasmicapp/plasmic/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=plasmicapp/plasmic" />
 </a>
+
+## Secrets (SOPS + age)
+- Repo vault: `.secrets/dev.env.enc` (encrypted dotenv)
+- Helper: `scripts/secrets` — `pull|edit|import|doctor`
+- Global defaults (optional): `Smarty-Pants-Inc/secrets/global/workstation.env.enc` → `~/.config/smarty/global.env`
+
+Local
+- Edit repo vault: `scripts/secrets edit dev`
+- Merge + write `.env.local`: `make secrets.pull && make secrets.doctor`
+
+CI
+- Add repo Actions secret `SOPS_AGE_KEY` (age private key)
+- Use composite action: `uses: ./.github/actions/sops-setup` with `sops_age_key: ${{ secrets.SOPS_AGE_KEY }}`
+- This writes `~/.config/age/key.txt`, installs `sops`, decrypts `.secrets/dev.env.enc` → `.env.local`, and exports keys to `GITHUB_ENV` for subsequent steps.

--- a/scripts/secrets
+++ b/scripts/secrets
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unified secrets helper (SOPS + age)
+# - pull: merge global (~/.config/smarty/global.env if present) + personal (~/.config/smarty/personal.env if present) + repo (.secrets/<env>.env.enc) → .env.local
+# - edit <env>: edit .secrets/<env>.env.enc with sops
+# - import <dotenv> [--env dev]: merge keys from plaintext dotenv into .secrets/<env>.env.enc
+# - doctor: validate required keys are present in .env.local (or decrypted contents)
+#
+# Env vars:
+#   SECRETS_ENV (default: dev)
+#   SOPS_AGE_KEY_FILE (optional; defaults to ~/.config/age/key.txt)
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_NAME="${SECRETS_ENV:-dev}"
+VAULT_PATH="$ROOT_DIR/.secrets/${ENV_NAME}.env.enc"
+GLOBAL_DIR="$HOME/.config/smarty"
+GLOBAL_ENV="$GLOBAL_DIR/global.env"
+AGE_KEY_DEFAULT="$HOME/.config/age/key.txt"
+
+ensure_age_key() {
+  if [[ -z "${SOPS_AGE_KEY_FILE:-}" ]]; then
+    export SOPS_AGE_KEY_FILE="$AGE_KEY_DEFAULT"
+  fi
+  if [[ ! -f "$SOPS_AGE_KEY_FILE" ]]; then
+    echo "Error: age private key not found at $SOPS_AGE_KEY_FILE" >&2
+    echo "Generate one: mkdir -p ~/.config/age && age-keygen -o ~/.config/age/key.txt" >&2
+    exit 1
+  fi
+}
+
+merge_envs() {
+  # args: <global_env_path or -> <repo_plain_path>
+  local global_in="$1" repo_in="$2"
+  awk -F= '
+    BEGIN { OFS = "=" }
+    function trim(s){ sub(/^\s+/, "", s); sub(/\s+$/, "", s); return s }
+    function is_kv(line){ return (line ~ /^[A-Za-z_][A-Za-z0-9_]*=.*/ ) }
+    {
+      if (FNR==1) fileidx++
+      line=$0
+      if (line ~ /^\s*#/ || line ~ /^\s*$/) next
+      if (!is_kv(line)) next
+      key=$1; sub(/^[^=]*=/, "", line); val=line
+      key=trim(key); val=val
+      if (fileidx==1) { seen[key]=val } else { seen[key]=val }
+    }
+    END {
+      for (k in seen) print k, seen[k]
+    }
+  ' "$global_in" "$repo_in"
+}
+
+cmd_pull() {
+  ensure_age_key
+  if [[ ! -f "$VAULT_PATH" ]]; then
+    echo "Error: vault not found: $VAULT_PATH" >&2
+    exit 1
+  fi
+  local tmp_repo="$ROOT_DIR/.secrets/.repo.$$.env"
+  sops -d --input-type dotenv --output-type dotenv "$VAULT_PATH" > "$tmp_repo"
+  local tmp_global="/dev/null"
+  local tmp_personal="/dev/null"
+  if [[ -f "$GLOBAL_ENV" ]]; then
+    tmp_global="$GLOBAL_ENV"
+  fi
+  if [[ -f "$GLOBAL_DIR/personal.env" ]]; then
+    tmp_personal="$GLOBAL_DIR/personal.env"
+  fi
+  local merged="$ROOT_DIR/.env.local"
+  case "$tmp_global:$tmp_personal" in
+    /dev/null:/dev/null)
+      # Repo only
+      grep -v "^#" "$tmp_repo" | sed '/^\s*$/d' > "$merged" ;;
+    /dev/null:*)
+      merge_envs "$tmp_personal" "$tmp_repo" | sort > "$merged" ;;
+    *:/dev/null)
+      merge_envs "$tmp_global" "$tmp_repo" | sort > "$merged" ;;
+    *)
+      # Merge global + personal first, then overlay repo
+      local tmp_gp="$ROOT_DIR/.secrets/.gp.$$.env"
+      merge_envs "$tmp_global" "$tmp_personal" | sort > "$tmp_gp"
+      merge_envs "$tmp_gp" "$tmp_repo" | sort > "$merged"
+      rm -f "$tmp_gp" ;;
+  esac
+  rm -f "$tmp_repo"
+  echo "Wrote $merged (env=$ENV_NAME)"
+}
+
+cmd_edit() {
+  local env_in="${1:-$ENV_NAME}"
+  local path="$ROOT_DIR/.secrets/${env_in}.env.enc"
+  if [[ ! -f "$path" ]]; then
+    echo "Info: creating $path"
+    printf "# %s env\n" "$env_in" > "$ROOT_DIR/.secrets/.seed.$$"
+    sops --encrypt \
+      --input-type dotenv --output-type dotenv \
+      --age "$(age-keygen -y "${SOPS_AGE_KEY_FILE:-$AGE_KEY_DEFAULT}")" \
+      --filename-override "$path" \
+      --encrypted-regex '^(.*)$' \
+      --output "$path" "$ROOT_DIR/.secrets/.seed.$$"
+    rm -f "$ROOT_DIR/.secrets/.seed.$$"
+  fi
+  sops "$path"
+}
+
+cmd_import() {
+  local dotenv_in="${1:-}"
+  if [[ -z "$dotenv_in" || ! -f "$dotenv_in" ]]; then
+    echo "Usage: $0 import <dotenv_file> [--env dev]" >&2
+    exit 2
+  fi
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env) ENV_NAME="$2"; VAULT_PATH="$ROOT_DIR/.secrets/${ENV_NAME}.env.enc"; shift 2 ;;
+      *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+  done
+  ensure_age_key
+  mkdir -p "$ROOT_DIR/.secrets"
+  local tmp_repo="$ROOT_DIR/.secrets/.repo.$$.env"
+  if [[ -f "$VAULT_PATH" ]]; then
+    sops --decrypt --input-type dotenv --output-type dotenv "$VAULT_PATH" > "$tmp_repo" || true
+  else
+    : > "$tmp_repo"
+  fi
+  # Merge: incoming overrides existing
+  awk -F= 'BEGIN{OFS="="}
+    function trim(s){ sub(/^\s+/,"",s); sub(/\s+$/, "", s); return s }
+    function is_kv(line){ return (line ~ /^[A-Za-z_][A-Za-z0-9_]*=.*/ ) }
+    FNR==NR {
+      if (!/^\s*#/ && is_kv($0)) { k=$1; sub(/^[^=]*=/, "", $0); src[k]=$0 }
+      next
+    }
+    {
+      if (!/^\s*#/ && is_kv($0)) { k=$1; sub(/^[^=]*=/, "", $0); dst[k]=$0 }
+    }
+    END {
+      for (k in dst) { if (!(k in src)) src[k]=dst[k] }
+      for (k in src) print k, src[k]
+    }
+  ' "$dotenv_in" "$tmp_repo" | sort > "$ROOT_DIR/.secrets/.merged.$$.env"
+  sops --encrypt \
+    --input-type dotenv --output-type dotenv \
+    --age "$(age-keygen -y "${SOPS_AGE_KEY_FILE:-$AGE_KEY_DEFAULT}")" \
+    --filename-override "$VAULT_PATH" \
+    --encrypted-regex '^(.*)$' \
+    --output "$VAULT_PATH" "$ROOT_DIR/.secrets/.merged.$$.env"
+  rm -f "$tmp_repo" "$ROOT_DIR/.secrets/.merged.$$.env"
+  echo "Imported into $VAULT_PATH"
+}
+
+cmd_doctor() {
+  local file="$ROOT_DIR/.env.local"
+  [[ -n "${1:-}" ]] && file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "Error: $file not found. Run: scripts/secrets pull" >&2
+    exit 1
+  fi
+  local -a required=(
+    SLACK_BOT_TOKEN
+    SLACK_SIGNING_SECRET
+    OPENAI_API_KEY
+    CEREBRAS_API_KEY
+    FORECAST_API_KEY
+  )
+  local missing=()
+  for k in "${required[@]}"; do
+    if ! rg -n "^${k}=" "$file" >/dev/null 2>&1; then
+      missing+=("$k")
+    else
+      local v
+      v=$(grep -E "^${k}=" "$file" | tail -n1 | cut -d'=' -f2-)
+      if [[ -z "$v" ]]; then missing+=("$k"); fi
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    echo "Missing/empty keys: ${missing[*]}" >&2
+    exit 2
+  fi
+  echo "Secrets check passed (${#required[@]} keys present)"
+}
+
+main() {
+  local cmd="${1:-pull}"; shift || true
+  case "$cmd" in
+    pull) cmd_pull ;;
+    edit) cmd_edit "$@" ;;
+    import) cmd_import "$@" ;;
+    doctor) cmd_doctor "$@" ;;
+    *) echo "Usage: $0 {pull|edit [env]|import <dotenv> [--env dev]|doctor [file]}"; exit 1 ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
This PR bootstraps SOPS + age for this repo.\n\nIncluded:\n- .sops.yaml (encrypts .secrets/*.env.enc to age recipient)\n- scripts/secrets helper (pull | edit | import | doctor)\n- .secrets/dev.env.enc placeholder (encrypted)\n- .gitignore hardened for backups\n\nUsage:\n- Edit repo vault: `scripts/secrets edit dev`\n- Pull merged view (with org defaults if present): `make secrets.pull && make secrets.doctor`\n- Global dev defaults: add to `Smarty-Pants-Inc/secrets/global/workstation.env.enc`, then refresh locallly: `sops -d --input-type dotenv --output-type dotenv global/workstation.env.enc > ~/.config/smarty/global.env`\n\nCI: If workflows need env, decrypt `.secrets/dev.env.enc` to `.env.local` with SOPS using the repo age key.\n