### PR TITLE
Add perserve-import-extensions

### DIFF
--- a/packages/cli/src/actions/sync.ts
+++ b/packages/cli/src/actions/sync.ts
@@ -74,6 +74,7 @@ export interface SyncArgs extends CommonArgs {
   allFiles?: boolean;
   skipFormatting?: boolean;
   skipBuffering?: boolean;
+  preserveImportExtensions?: boolean;
 }
 
 async function ensureRequiredPackages(
@@ -187,6 +188,10 @@ export async function sync(
 
   if (opts.skipFormatting) {
     GLOBAL_SETTINGS.skipFormatting = true;
+  }
+
+  if (opts.preserveImportExtensions) {
+    GLOBAL_SETTINGS.preserveImportExtensions = true;
   }
 
   const isFirstRun = context.config.projects.length === 0;

--- a/packages/cli/src/globals.ts
+++ b/packages/cli/src/globals.ts
@@ -1,3 +1,4 @@
 export const GLOBAL_SETTINGS = {
   skipFormatting: false,
+  preserveImportExtensions: false,
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -398,6 +398,12 @@ function configureSyncArgs(
         "Write files directly to disk, instead of buffering and only writing if sync completes successfully",
       default: false,
     })
+    .option("preserve-import-extensions", {
+      type: "boolean",
+      describe:
+        "Preserve file extensions in import statements (e.g., './Component.jsx' instead of './Component')",
+      default: false,
+    })
     .option("all-files", {
       type: "boolean",
       describe:

--- a/packages/cli/src/utils/code-utils.ts
+++ b/packages/cli/src/utils/code-utils.ts
@@ -556,7 +556,7 @@ function makeImportPath(
       result = `./${result}`;
     }
   }
-  if (stripExt) {
+  if (stripExt && !GLOBAL_SETTINGS.preserveImportExtensions) {
     result = stripExtension(result);
   }
 


### PR DESCRIPTION
 ## Add `--preserve-import-extensions` flag to Plasmic CLI

  ### Problem

Currently, the Plasmic sync process automatically strips file extensions from import statements in generated code. For example, if a file has `import Component from "./Component.jsx"`, the sync will transform it to `import Component from "./Component"`.

  This behavior is problematic for projects that:
  - Use ESM modules with Node.js (which requires explicit file extensions)
  - Have specific bundler configurations that expect explicit extensions
  - Follow coding standards that mandate file extensions in imports
  - Use TypeScript with `moduleResolution: "node16"` or `"nodenext"`

  ### Solution

This PR adds a new `--preserve-import-extensions` flag that prevents the CLI from stripping file extensions during the sync process.

  ### Usage

  ```bash
  plasmic sync --preserve-import-extensions

  When enabled, import statements will preserve their original file extensions:
  - Before: import Component from "./Component"
  - After: import Component from "./Component.jsx"

  Implementation

  The flag is implemented by:
  1. Adding a new global setting preserveImportExtensions
  2. Adding the CLI flag to the sync command options
  3. Modifying the makeImportPath() function to conditionally skip extension stripping when the flag is set

  The default behavior remains unchanged (extensions are stripped) to maintain backward compatibility.
  ```